### PR TITLE
issue 12 solved by making rooms ordered by name

### DIFF
--- a/app/services/impl/LaboratoryServiceImpl.scala
+++ b/app/services/impl/LaboratoryServiceImpl.scala
@@ -1,23 +1,23 @@
 package services.impl
 
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.{ Inject, Singleton }
 import dao.LaboratoryDAO
 import model._
 import services.LaboratoryService
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
-  * @author Camilo Sampedro <camilo.sampedro@udea.edu.co>
-  */
+ * @author Camilo Sampedro <camilo.sampedro@udea.edu.co>
+ */
 @Singleton
-class LaboratoryServiceImpl @Inject()(laboratoryDAO: LaboratoryDAO)(implicit executionContext: ExecutionContext) extends LaboratoryService {
+class LaboratoryServiceImpl @Inject() (laboratoryDAO: LaboratoryDAO)(implicit executionContext: ExecutionContext) extends LaboratoryService {
   /**
-    * Get a laboratory by its ID
-    *
-    * @param id Laboratory ID
-    * @return Laboratory with rooms and each room with computers
-    */
+   * Get a laboratory by its ID
+   *
+   * @param id Laboratory ID
+   * @return Laboratory with rooms and each room with computers
+   */
   def get(id: Long): Future[Option[(Laboratory, Map[Option[Room], Seq[(Computer, Option[(ComputerState, Seq[ConnectedUser])])]])]] = {
     // Access to database using the laboratory's DAO
     laboratoryDAO.getWithChildren(id).map { res =>
@@ -29,16 +29,18 @@ class LaboratoryServiceImpl @Inject()(laboratoryDAO: LaboratoryDAO)(implicit exe
         // If there's at least one element on the list, get the first one
         case Some((laboratory, rooms)) =>
 
-          val roomsWithComputers = rooms.map {
-            // Result will have the same elements as in the above "res", so clean the already known laboratory
-            groupedElements => (groupedElements._2, groupedElements._3)
-          }.groupBy {
+          val flattenedRooms = for {
+            room <- rooms
+            validRoom <- room._2
+          } yield (validRoom, room._3)
+
+          val roomsWithComputers = flattenedRooms.sortBy(_._1.name).groupBy {
             // And group by room
             cleanedGroupedElements => cleanedGroupedElements._1
           }.map {
             // If the grouped elements follow this schema
-            case (maybeRoom, groupedRoomWithComputers) =>
-              (maybeRoom, groupedRoomWithComputers
+            case (room, groupedRoomWithComputers) =>
+              (Option(room), groupedRoomWithComputers
                 // Clean already known "maybeRoom"
                 .map(_._2)
                 // Group by computer
@@ -48,7 +50,7 @@ class LaboratoryServiceImpl @Inject()(laboratoryDAO: LaboratoryDAO)(implicit exe
                     // If there is a computer state related to this computer, clean  and package them
                     case (_, Some(state), user) => Some((state, user))
                     // If there is not, save a None
-                    case _ => None
+                    case _                      => None
                   }))
                   // If it is not a computer here, save a None
                   case _ => None
@@ -69,16 +71,12 @@ class LaboratoryServiceImpl @Inject()(laboratoryDAO: LaboratoryDAO)(implicit exe
                     // Reverse it to get the latest as the first element
                     .reverse
                     // And save that optional first element
-                    .headOption
-                    )
+                    .headOption)
                 }.toSeq
                 // Sort computers by their IP address
-                .sortBy(_._1.ip)
-                )
-          }.filter {
-            // Filter defined rows
-            row => row._1.isDefined
+                .sortBy(_._1.ip))
           }
+          
           // Return the laboratory with its packaged rooms and computers
           Some(laboratory, roomsWithComputers)
         case e =>


### PR DESCRIPTION
**Issue solved is [#12](https://github.com/camilosampedro/Aton/issues/12)**
1. Why this change is necessary?
   To allow a proper room sorting by name as required by the issue.
2. How does it address the issue?
   By introducing a for comprehension I've filtered the optional rooms and ordered before to apply all the maps operations within the `services.impl.LaboratoryServiceImpl.get(id: Long)` method.
3. What side effects does this change have?
   I've added also a little bit of code formatting on the affected class.

Please note that, since the Option[Room] filtering is already defined by the new for comprehension, [this filtering](https://github.com/camilosampedro/Aton/blob/master/app/services/impl/LaboratoryServiceImpl.scala#L78) is no more necessary.
