### PR TITLE
Add missing translation strings for login page

### DIFF
--- a/app/views/login.scala.html
+++ b/app/views/login.scala.html
@@ -27,11 +27,11 @@
                     <input type="text" name="username" placeholder="@messages("user.username")" id="username" value="@form("username").value">
                 </p>
                 <p>
-                    <input type="password" name="password" id="password" placeholder="Password">
+                    <input type="password" name="password" id="password" placeholder="@messages("user.password")">
                 </p>
                 <p>
-                    <button type="submit" class="btn">
-                        Login</button><button class="btn btn-default"><a href="@routes.HomeController.home()" role="button">@messages("user.goToHome")</a></button>
+                    <button type="submit" class="btn">@messages("user.loginAction")</button>
+                    <button class="btn btn-default"><a href="@routes.HomeController.home()" role="button">@messages("user.goToHome")</a></button>
                 </p>
 
             }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -50,8 +50,10 @@ laboratory.help.head=Ingresando un nuevo laboratorio
 laboratory.help.body=Aquí podrás ingresar un nuevo laboratorio al sistema.
 # User
 user.username=Nombre de usuario
+user.password=Password
 user.not_logged_in=No has iniciado sesión
 user.login=Iniciar sesión
+user.loginAction=Login
 user.loginFormTitle=Inicia sesión en el sistema
 user.goToHome=Volver a la página de inicio
 # SSH Order

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -109,9 +109,11 @@ laboratory.register.title=Registrar laboratorio
 
 # User
 user.username=Nombre de usuario
+user.password=Password
 user.not_logged_in=No has iniciado sesión
 user.logout=Cerrar sesión
 user.login=Iniciar sesión
+user.loginAction=Login
 user.loginFormTitle=Inicia sesión en el sistema
 user.goToHome=Volver a la página de inicio
 user.connectedusers=Usuarios conectados:


### PR DESCRIPTION
Hi again!
## PR Breakdown

This PR adds two more translation endpoints on the login page, the caption of the login button and the placeholder of the password field. It also adds translations to the English and Spanish messages files.
## Justification

This change is necessary because not all languages have the same words for password and login.
## Implementation

This commit addresses the issue by changing the login template to request translations for these two strings and adding respective translations to the existing messages files.
## Caveats

This change adds new strings, so all translations that are not shipped with this PR need to update accordingly. #28 for the German translation has been updated already.

Thanks!
