### PR TITLE
Fix Laboratory List Internationalisation

### DIFF
--- a/app/views/laboratories.scala.html
+++ b/app/views/laboratories.scala.html
@@ -3,7 +3,7 @@
 @(laboratories: Seq[Laboratory])(implicit messages: Messages, isAdmin: Boolean)
 <div class="row"><div class="col-md-12">
     <div class="panel panel-primary">
-        <div class="panel-heading">Laboratorios</div>
+        <div class="panel-heading">@messages("laboratory.list.title")</div>
         <div class="panel-body">
             @if(laboratories.nonEmpty) {
                 <table class="table table-striped" ng-if={laboratorios.nombre}>
@@ -31,9 +31,9 @@
                         <td>@laboratory.location</td>
                         <td>@laboratory.administration</td>
                             @if(isAdmin) {
-                                <td><a href="@adminroutes.LaboratoryController.edit(laboratory.id)">Editar</a></td>
+                                <td><a href="@adminroutes.LaboratoryController.edit(laboratory.id)">@messages("edit")</a></td>
                                 <td><a href="@adminroutes.LaboratoryController.delete(laboratory.id)">
-                                    Eliminar</a></td>
+                                    @messages("delete")</a></td>
                             }
                         </tr>
                     }


### PR DESCRIPTION
Hi!
## PR Breakdown

This PR makes use of the previously unused `laboratory.list.title` string and also uses the `delete` and `edit` strings for each laboratory in the list, instead of defaulting to static strings in Spanish.
## Justification

This is necessary to improve translation coverage.
## Implementation

This is implemented by replacing the static strings with i18n expreressions. It has been confirmed working with the German translation, as depicted in below screenshot:

![Screenshot showing the list of laboratories with the strings in question translated to German](https://cloud.githubusercontent.com/assets/547070/19225182/ecdf4478-8e96-11e6-8c00-e1a68b941ae2.png)
## Caveats

The only known issue with this is that new translations might not have that string because they thought it was not implemented, but that could be considered a minor issue.

Thanks!
