### PR TITLE
Fix inconsistent "suggestion" translation in German

### DIFF
--- a/conf/messages.de
+++ b/conf/messages.de
@@ -60,7 +60,7 @@ header.editUser=Benutzer bearbeiten
 
 # Menu texts
 menu.home=Hauptseite
-menu.suggestions=Tipps
+menu.suggestions=Anfragen
 menu.administration=Administration
 menu.laboratories=Räume
 menu.sshorders=SSH-Befehle


### PR DESCRIPTION
Hi again!
## PR Breakdown

This PR fixes the menu name for suggestions in German being different from the word used everywhere else. I noticed this when looking at the screenshot from #30 again. The reason it was different is because the menu items are declared somewhere else than the rest of the suggestion-related strings, so I missed it when updating the translation with the new word. 
## Justification

This is necessary because we strive to be consistent in our wording. Sorry for the inconvenience.
