### PR TITLE
Add Block User Dialog

### DIFF
--- a/app/model/form/BlockUserForm.scala
+++ b/app/model/form/BlockUserForm.scala
@@ -1,0 +1,16 @@
+package model.form
+
+import model.form.data.BlockUserFormData
+import play.api.data.Form
+import play.api.data.Forms._
+
+/**
+  * @author Benjamin R. White <ben@delt.as>
+  */
+object BlockUserForm {
+  val form = Form(
+    mapping(
+      "blockUser.username" -> nonEmptyText
+    )(BlockUserFormData.apply)(BlockUserFormData.unapply)
+  )
+}

--- a/app/model/form/data/BlockUserFormData.scala
+++ b/app/model/form/data/BlockUserFormData.scala
@@ -1,0 +1,6 @@
+package model.form.data
+
+/**
+  * @author Benjamin R. White <ben@delt.as>
+  */
+case class BlockUserFormData(username: String)

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -15,6 +15,7 @@ import scala.concurrent.Future
 trait UserService {
   def checkAndGet(form: LoginFormData): Future[Option[User]] = checkAndGet(form.username, form.password)
   def add(user: User): Future[ActionState]
+  def listAll: Future[Seq[User]]
   def get(username: String): Future[Option[User]]
   def checkAndGet(username: String, password: String): Future[Option[User]]
 }

--- a/app/services/impl/UserServiceImpl.scala
+++ b/app/services/impl/UserServiceImpl.scala
@@ -18,4 +18,6 @@ class UserServiceImpl @Inject()(userDAO: UserDAO)(implicit executionContext: Exe
   override def get(username: String): Future[Option[User]] = userDAO.get(username)
 
   override def checkAndGet(username: String, password: String): Future[Option[User]] = userDAO.checkAndGet(username,password)
+
+  override def listAll: Future[Seq[User]] = userDAO.listAll
 }

--- a/app/views/blockUser.scala.html
+++ b/app/views/blockUser.scala.html
@@ -1,0 +1,30 @@
+@import controllers.admin.{routes => adminroutes}
+@(blockUserForm: Form[model.form.data.BlockUserFormData], roomId: Long, users: Seq[(String, String)])(implicit messages: Messages)
+    @implicitField = @{
+        helper.FieldConstructor(fieldConstructorTemplate.f)
+    }
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title">@messages("room.blockUser.title")</h4>
+                </div>
+                <div class="modal-body">
+                    @helper.form(
+                        action = adminroutes.RoomController.blockUser(roomId),
+                        'id -> "blockUserDialogForm"
+                    ) {
+                        @helper.select(
+                            blockUserForm("userBlock.username"),
+                            users,
+                            'class -> "form-control",
+                            'placeholder -> messages("room.blockUser.userPlaceholder")
+                        )
+                    }
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">@messages("room.blockUser.cancel")</button>
+                    <button type="submit" class="btn btn-primary" form="blockUserDialogForm">@messages("room.blockUser.confirm")</button>
+                </div>
+        </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -42,5 +42,6 @@
                 <div class="content">@content</div>
             </div>
         </div>
+        <div class="modal fade" tabindex="-1" role="dialog"></div>
     </body>
 </html>

--- a/app/views/roomPanel.scala.html
+++ b/app/views/roomPanel.scala.html
@@ -5,7 +5,9 @@
     <div class="col-md-12 room-panel">
         <div class="panel panel-primary">
             <div class="panel-heading icon ion-easel"> @room.name @if(isAdmin) {
-                <a href="@adminroutes.RoomController.edit(room.id)" class="btn btn-warning icon ion-edit pull-right" role="button" title="@messages("room.edit")"></a> <a href="@adminroutes.RoomController.delete(room.id)" title="@messages("room.delete")" class="btn btn-danger icon ion-minus pull-right" role="button"></a>
+                <a href="@adminroutes.RoomController.edit(room.id)"><div class="btn btn-warning icon ion-edit pull-right" role="button" title="@messages("room.edit")"></div></a>
+                <a href="@adminroutes.RoomController.delete(room.id)" title="@messages("room.delete")"><div class="btn btn-danger icon ion-minus pull-right" role="button"></div></a>
+                <div data-href="@adminroutes.RoomController.blockUserForm(room.id)" title="@messages("room.blockUser")" class="btn btn-danger icon ion-android-hand pull-right ajax-modal" role="button"></div>
             }</div>
             <div class="panel-body">
             @if(computers.nonEmpty) {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -26,6 +26,12 @@ computer.list.empty.body=Parece que no se han encontrado computadores.
 room.edit=Editar
 room.notFound=Sala no encontrada con el id especificado
 room.add_room=Agregar sala
+
+room.blockUser.title=Block User
+room.blockUser.userPlaceholder=User to block
+room.blockUser.cancel=Cancel
+room.blockUser.confirm=Submit
+
 # Suggestion
 suggestion.notImplemented=El módulo de sugerencias no está implementado... aún
 # General

--- a/conf/messages.es
+++ b/conf/messages.es
@@ -87,6 +87,11 @@ room.register.title=Registrar sala
 room.help.head=Ingresar una nueva sala
 room.help.body=Aquí podrás ingresar una nueva sala al sistema. Las salas son conjuntos de computadoras.
 
+room.blockUser.title=Bloquear usuario
+room.blockUser.userPlaceholder=usuario para bloquear
+room.blockUser.cancel=Cancelar
+room.blockUser.confirm=Agregar
+
 # Suggestion
 suggestion.notImplemented=El módulo de sugerencias no está implementado... aún
 

--- a/conf/routes
+++ b/conf/routes
@@ -27,6 +27,8 @@ POST        /room/add                        controllers.admin.RoomController.ad
 GET         /room/edit/:roomId               controllers.admin.RoomController.editForm(roomId:Long)
 POST        /room/edit/:roomId               controllers.admin.RoomController.edit(roomId:Long)
 GET         /room/delete/:roomId             controllers.admin.RoomController.delete(roomId:Long)
+GET         /room/blockuser/:roomId          controllers.admin.RoomController.blockUserForm(roomId:Long)
+POST        /room/blockuser/:roomId          controllers.admin.RoomController.blockUser(roomId:Long)
 
 # Computer
 POST        /computer/add                    controllers.admin.ComputerController.add

--- a/public/javascripts/general.js
+++ b/public/javascripts/general.js
@@ -20,5 +20,20 @@ $(document).ready(function () {
         commandBox.find(".modal-body #blockpageform").attr("action", "/computer/blockpage/" + event.target.id);
         commandBox.find(".modal-body #sendmessageform").attr("action", "/computer/sendmessage/" + event.target.id);
         commandBox.modal('show');
-    })
+    });
+    $(".ajax-modal").click(function (event) {
+        console.log("Clicked " + event.target.id);
+        var target = $(event.target);
+        if(target.data('toggled')) {
+            // prevent double-click during request
+            return;
+        }
+        target.data('toggled', true);
+        var href = target.attr('data-href');
+        var modalContainer = $('body > .modal');
+        modalContainer.load(href, function () {
+            target.data('toggled', false);
+            modalContainer.modal('show');
+        });
+    });
 });


### PR DESCRIPTION
[Closes #14](https://github.com/camilosampedro/Aton/issues/14)
1. Why this change is necessary?
   A button is required on the room panel, to open a dialog that can then
   be used to block a user from the room
2. How does it address the issue?
   - Two routes and related methods are added to RoomController:
     - To fetch the modal contents, including the form for a room via a request
     - To submit the user selection
   - A new template is added to scaffold the modal contents:
     blockUser.scala.html
   - index.scala.html is modified to add a modal target div
   - A new method is added to the UserService Trait, listAll (to list all users)
     for scaffolding the select form field to choose the user
   - Javascript is added to general.js that will handle the loading of the
     dialog content
   - The button is added to roomPanel.scala.html, including a data attribute
     giving the target url to ask for the modal content
3. What side effects does this change have?
   
   This is a relatively small change, and I do not believe it will have any
   side-effects.
