### PR TITLE
Add docker container configuration and dependency caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
+sudo: required
 language: scala
-scala:
-  - 2.11.8
+services:
+  - docker
+cache:
+  directories:
+    - .ivy2
+before_install:
+  - mkdir -p .ivy2
+  - docker pull mariadb
+  - docker pull 1science/sbt
+  - docker network create -d bridge --subnet 172.25.0.0/16 services
+  - docker run -tid --name aton-mariadb --network=services -e MYSQL_ROOT_PASSWORD=password mariadb
+  - export MARIADB_SERVER=$(docker network inspect services | jq -r '.[0].Containers[] | select(.Name = "aton-mariadb") | .IPv4Address | match("^[^\/]+").string')
+  - repeat=60; while (( repeat > 0 )) && ! timeout 1 bash -c "echo > /dev/tcp/$MARIADB_SERVER/3306" > /dev/null 2>&1 ; do sleep 1; repeat=$((( repeat - 1))); done; ((repeat > 0))
+  - cat conf/default/create.sql | mysql -h $MARIADB_SERVER -u root -ppassword
 script:
-  - sbt test compile
-jdk:
-  - oraclejdk8
+  - docker run -ti --rm -v "$PWD:/src" -v "$PWD/.ivy2":/root/.ivy2 --network=services 1science/sbt /bin/sh -c "cd /src; sbt clean test compile"
 notifications:
   email:
     - camilo.sampedro@udea.edu.co


### PR DESCRIPTION
**[Issue #45](https://github.com/camilosampedro/Aton/issues/45)**

1. Why this change is necessary?
This change containerizes the build environment, allowing the CI process to be more closely reflected in a development environment. The addition of a mysql-compatible container will allow selenium (or similar) driven integration testing of the application. Finally the addition of caching of the build dependencies speeds builds up by a factor of 4. (2 minutes as opposed to 8)

2. How does it address the issue?
The container is specified as described in the issue.

3. What side effects does this change have?
Travis no longer controls the version of scala that we are using, instead we need to pin to a version of [1science/docker-sbt](/1science/docker-sbt) that gives us the scala version that we want to test against.